### PR TITLE
exclude .svn and .git from the pattern inc() function

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -17,6 +17,31 @@ Name: the name of the file
 	
 ************** */
 
+
+/**
+ * Provide a filter for excluding hidden .git or .svn folders from the inc() function
+ */
+class ExcludeFilter extends RecursiveFilterIterator {
+	
+	public static $FILTERS = array(
+		'.svn',
+		'.git'	
+	);
+	
+	public function accept() {
+		//Check if a file is within one of the folders listed in the exclude list
+		foreach(self::$FILTERS as $filter) {
+			if(strpos($this->current()->getPath(),$filter)) {
+				return false;
+			}
+		}
+		return true;
+	}
+}
+
+
+
+
 function inc($type,$name) {
 	global $patternsPath; 
 	global $absolutePath;
@@ -38,7 +63,7 @@ function inc($type,$name) {
 	
 	
 	//Iterate over the appropriate path
-	$objects = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($filePath));
+	$objects = new RecursiveIteratorIterator(new ExcludeFilter(new RecursiveDirectoryIterator($filePath)));
 	foreach($objects as $objName => $object){
 	
 		$pos = stripos($objName, $name);

--- a/styleguide.php
+++ b/styleguide.php
@@ -48,8 +48,11 @@ function displayPatterns($dir,$exclude){
 	            	}
 	            } 
 	            
-	            if(is_dir($dir.'/'.$ff)) {
-	            	if($ff!='03-Templates' || $ff!='04-Pages') { //Exclude displaying the templates 
+            	if(is_dir($dir.'/'.$ff)) {
+	            	if(!in_array($ff, array(
+	            		'03-Templates',
+	            		'04-Pages'
+	            	))) { //Exclude displaying the templates 
 	            		displayPatterns($dir.'/'.$ff,$exclude);
 	            	}
 	            }


### PR DESCRIPTION
This is a weird bug. On Windows systems, if this project is included in an SVN project, the inc() function will parse the cached file originals in the .svn folder instead of locally modified files. As a result, any atoms/molecules/organisms loaded through the inc() function won't display any local modifications.

This commit adds an Exclude Filter to the recursive directory scanner so that .svn and .git folders are excluded. It also makes it easier to add additional path-based filters for excluding from the inc() scanner.
