### PR TITLE
remove address element and replace with correct microformats

### DIFF
--- a/patterns/00-Atoms/00-Text/04-Address.php
+++ b/patterns/00-Atoms/00-Text/04-Address.php
@@ -1,1 +1,11 @@
-<address>Address Name<br />1234 Main St.<br />Anywhere, US 101010</p> </address>
+<div class="vcard">
+	<div class="org">Company Name</div>
+	<div class="adr">
+		<div class="street-address">1234 Main St.</div>
+		<span class="locality">Anywhere</span>,
+		<span class="postal-code">101010</span>,
+		<abbr class="region" title="California">CA</abbr>
+		<div class="country-name">U.S.A</div>
+	</div>
+	<div class="tel">+1.888.123.4567</div>
+</div>


### PR DESCRIPTION
Remove <address> element and replace with correct microformats to avoid spreading the common mistake of using <address> to markup hCard data.
